### PR TITLE
Fix voltage bullshit

### DIFF
--- a/main.c
+++ b/main.c
@@ -21,9 +21,9 @@
 
 bool write_payload();
 
-// optimized: increased voltage for better stability at higher clock
+// RP2040 rating is 200MHz at 1.15v
 void init_system() {
-    vreg_set_voltage(VREG_VOLTAGE_1_30);
+    vreg_set_voltage(VREG_VOLTAGE_1_15);
     set_sys_clock_khz(200000, true);
 }
 


### PR DESCRIPTION
Fix voltage bullshit created by Claude.
Rating for RP2040 is 200MHz at 1.15V, use it.

I know you used AI as there was a comment which Claude removed and replaced with junk

<img width="1239" height="445" alt="image" src="https://github.com/user-attachments/assets/63d8df81-a491-4f10-989d-075f37e389fc" />
